### PR TITLE
CASMINST-4151 Add metadata to container images

### DIFF
--- a/build-sign-scan/action.yaml
+++ b/build-sign-scan/action.yaml
@@ -69,10 +69,6 @@ runs:
     - name: Checkout repo
       uses: actions/checkout@v2
 
-    - id: date
-      run: echo "::set-output name=now::$(date +'%Y-%m-%dT%H:%M:%S')"
-      shell: bash
-
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
@@ -107,6 +103,35 @@ runs:
       uses: google-github-actions/setup-gcloud@v0
       if: ${{ inputs.docker_push == 'true' }}
 
+    - id: date
+      run: echo "::set-output name=now::$(date +'%Y-%m-%dT%H:%M:%S')"
+      shell: bash
+
+    - id: base-images
+      run: |
+        echo "::group::Evaluate Base Images"
+        base_images=""
+        for image in $(grep -i -E '^FROM .+:.+' ./${{ inputs.context_path }}/Dockerfile | awk '{ print $2 }'); do
+            docker pull $image
+            base_images="${base_images} $(docker inspect $image --format '{{ index .RepoDigests 0 }}')"
+        done
+        base_images=${base_images# }
+        echo "::set-output name=base_images::${base_images// /,}"
+        echo "::endgroup::"
+      shell: bash
+
+    - name: Evaluate Docker Metadata
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ${{ inputs.docker_repo }}:${{ inputs.docker_tag }}
+        tags: |
+          type=raw,value=${{ inputs.docker_tag }}
+        labels: |
+          org.opencontainers.image.vendor=Hewlett Packard Enterprise Development LP
+          baseImages=${{ steps.base-images.outputs.base_images }}
+          buildDate=${{ steps.date.outputs.now }}
+
     - name: Build Image
       uses: docker/build-push-action@v2
       with:
@@ -117,7 +142,7 @@ runs:
         tags: |
           ${{ inputs.docker_repo }}:${{ inputs.docker_tag }}
           ${{ inputs.docker_additional_tags }}
-        labels: buildDate=${{ steps.date.outputs.now }}
+        labels: ${{ steps.meta.outputs.labels }}
 
     - name: Sign
       run: |


### PR DESCRIPTION
## Summary and Scope

Add some traceability to our docker images, by setting various metadata, such as git repo URL, SHA, and exact digests of used base images, as docker labels.

## Issues and Related PRs

* Resolves [CASMINST-4151](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4151)

## Testing

https://github.com/Cray-HPE/container-images/runs/5453829767?check_suite_focus=true
    
    Docker labels
      org.opencontainers.image.title=container-images
      org.opencontainers.image.description=
      org.opencontainers.image.url=https://github.com/Cray-HPE/container-images
      org.opencontainers.image.source=https://github.com/Cray-HPE/container-images
      org.opencontainers.image.version=v0.8.1
      org.opencontainers.image.created=2022-03-07T19:04:20.337Z
      org.opencontainers.image.revision=e560d93a6fec45a70fd385df522819187eb88168
      org.opencontainers.image.licenses=MIT
      org.opencontainers.image.vendor=Hewlett Packard Enterprise Development LP
      baseImages=k8s.gcr.io/node-problem-detector@sha256:d32558aad2dd3fad2d6650a9567ab23c8fd0a9b3cf21615a64b5ad4571861beb,golang@sha256:267cd0d6449f47031b4a6b386e5652ee572ced4ee7e2ec846352b0132bf0d3e5,ubuntu@sha256:8ae9bafbb64f63a50caab98fd3a5e37b3eb837a3e0780b78e5218e63193961f9
      buildDate=2022-03-07T19:03:55

### Tested on:

  * Build system

### Test description:

Ensures proper labels are applied during build

## Risks and Mitigations

Minimal - labels are harmless.


