### PR TITLE
CASMSEC-344 Add support for docker buildkit secrets

### DIFF
--- a/build-sign-scan/action.yaml
+++ b/build-sign-scan/action.yaml
@@ -62,6 +62,8 @@ inputs:
     default: false
   docker_build_args:
     default: ""
+  docker_secrets:
+    default: ""
   docker_additional_tags:
     default: ""
   docker_keep_revisions:
@@ -142,9 +144,10 @@ runs:
           buildDate=${{ steps.strings.outputs.now }}
 
     - name: Build Image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         build-args: ${{ inputs.docker_build_args }}
+        secrets: ${{ inputs.docker_secrets }}
         context: ${{ inputs.context_path }}
         push: ${{ inputs.docker_push }}
         load: ${{ (inputs.docker_push != 'true') && 'true' || 'false' }}


### PR DESCRIPTION
## Summary and Scope

Added support for docker secrets to build-sign-scan shared action. This allows to pass secrets into docker build context, without exposing them in image build history (which happens when data are passed via `--build-arg` option).

## Issues and Related PRs

* Needed for [CASMSEC-344](https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-344)

## Testing
### Tested on:

  * Github

### Test description:

Running on feature branch demonstrates successful propagation of secrets:
https://github.com/Cray-HPE/container-images/actions/runs/2828262133

## Risks and Mitigations

Low - backwards compatible change in build pipeline.
