### PR TITLE
CASMINST-5570 Address deprecation notices in shared workflows

### DIFF
--- a/build-sign-scan/action.yaml
+++ b/build-sign-scan/action.yaml
@@ -74,14 +74,14 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Login to algol60 Container Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ${{ inputs.docker_registry }}
         username: ${{ inputs.artifactory_algol60_username }}
@@ -112,9 +112,9 @@ runs:
 
     - id: strings
       run: |
-          echo "::set-output name=now::$(date +'%Y-%m-%dT%H:%M:%S')"
-          echo "::set-output name=timestamp::$(date +'%Y%m%d%H%M%S')"
-          echo "::set-output name=gitsha::${GITHUB_SHA::7}"
+          echo "now=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_OUTPUT
+          echo "timestamp=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
+          echo "gitsha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
       shell: bash
 
     - id: base-images
@@ -127,13 +127,13 @@ runs:
             base_images="${base_images} $(docker inspect $image --format '{{ index .RepoDigests 0 }}')"
         done
         base_images=${base_images# }
-        echo "::set-output name=base_images::${base_images// /,}"
+        echo "base_images=${base_images// /,}" >> $GITHUB_OUTPUT
         echo "::endgroup::"
       shell: bash
 
     - name: Evaluate Docker Metadata
       id: meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v4
       with:
         images: ${{ inputs.docker_repo }}:${{ inputs.docker_tag }}
         tags: |


### PR DESCRIPTION
## Summary and Scope

Shared actions display deprecation notices, such as:
* Deprecation of NodeJS 12 (in favor of NodeJS 16)
* Deprecation of `set-output` and `save-state` commands: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This change is to address warnings before things stop working.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5570](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5570)

## Testing
### Tested on:

  * Test run of container build in dedicated branch: https://github.com/Cray-HPE/github-ephemeral-runners/actions/runs/3380325788/jobs/5613163346

### Test description:

Ensured that warnings about NodeJS version had gone and output commands are processed correctly.

## Risks and Mitigations

Low - can be easily rolled back.