### PR TITLE
CASMINST-5856 Add support for snyk --exclude-app-vulns

### DIFF
--- a/build-sign-scan/action.yaml
+++ b/build-sign-scan/action.yaml
@@ -56,6 +56,8 @@ inputs:
     required: true
   github_sha:
     required: true
+  snyk_exclude_app_vulns:
+    default: false
   fail_on_snyk_errors:
     default: false
   fail_on_trivy_action_vulnerabilities:
@@ -215,7 +217,7 @@ runs:
       uses: docker://docker.io/snyk/snyk:docker
       id: snyk
       with:
-        args: snyk test --docker ${{ inputs.docker_repo }}:${{ inputs.docker_tag }}
+        args: snyk test --docker ${{ inputs.docker_repo }}:${{ inputs.docker_tag }} ${{ inputs.snyk_exclude_app_vulns == 'true' && '--exclude-app-vulns' || '' }}
       env:
         SNYK_TOKEN: ${{ inputs.snyk_token }}
       continue-on-error: true


### PR DESCRIPTION
## Summary and Scope

Added support for `snyk_exclude_app_vuls` input parameter, which translates into `--exlude-app-vuls` cli option of the snyk scan.

## Issues and Related PRs

* Resolves [CASMINST-5856](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5856)

## Testing
### Tested on:

  * Github

### Test description:

1. Test for default setting (vulns exist, cli option absent, build failed): https://github.com/Cray-HPE/iuf-containers/actions/runs/4010446280/jobs/6887058439
2. Test for overridden setting (vulns exist, cli option provided, build successful): https://github.com/Cray-HPE/iuf-containers/actions/runs/4010516482/jobs/6887108418

## Risks and Mitigations

Low - new optional parameter