### PR TITLE
Upgrade docker/build-push-action to v4

### DIFF
--- a/build-sign-scan/action.yaml
+++ b/build-sign-scan/action.yaml
@@ -146,7 +146,7 @@ runs:
           buildDate=${{ steps.strings.outputs.now }}
 
     - name: Build Image
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v4
       with:
         build-args: ${{ inputs.docker_build_args }}
         secrets: ${{ inputs.docker_secrets }}


### PR DESCRIPTION
## Summary and Scope

On Jan 14 2023, version `v3` of `docker/build-push-action` introduced a backwards incompatible behavior (with version `3.3.0`): it enabled minimal SLSA provenance attestation, which implicitly converted builds from legacy single-platform to OCI-compliant multi-platform. On Jan 30,  in version `3.3.1`, this behavior was turned off by default:
https://github.com/docker/build-push-action/releases

However, images produced in the time range Jan 14 - Jan 30 are multi-platform, so they override single-platform images with the same tag. So any `docker pull` or `skopeo inspect` operation takes latest multi-platform image from Jan 30th, and does not take into account single-platform images built after this date.

The easiest solution to fix this problem is to upgrade to `v4` of `docker/build-push-ation`, which again makes multi-platform images default.

## Issues and Related PRs

* Resolves [CASMINST-5984](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5987)

## Testing
### Tested on:

  * Github workflow

### Test description:

* Created temporary branch on `container-images` repo, which uses `Cray-HPE/github-actions/build-sign-scan` action from unmerged `feature/docker-build-push-v4` branch, and performs push to artifactory
* Verified that image with the same digest is pushed by temporary branch build and pulled by 1docker pull` command:

https://github.com/Cray-HPE/container-images/actions/runs/4187898010/jobs/7258346055

      #7 pushing manifest for artifactory.algol60.net/csm-docker/stable/velero/velero:v1.7.1@sha256:94f51ca6ad57c2f2d8b57040f38cf29e4191ea2884ea796bd6df709e7e63d2ea

and then

      $ docker pull artifactory.algol60.net/csm-docker/stable/velero/velero:v1.7.1
      v1.7.1: Pulling from csm-docker/stable/velero/velero
      b49b96595fd4: Already exists
      9411f38bb959: Already exists
      82376eab0a28: Already exists
      Digest: sha256:94f51ca6ad57c2f2d8b57040f38cf29e4191ea2884ea796bd6df709e7e63d2ea
      Status: Downloaded newer image for artifactory.algol60.net/csm-docker/stable/velero/velero:v1.7.1
      artifactory.algol60.net/csm-docker/stable/velero/velero:v1.7.1

## Risks and Mitigations

Low - this only restores behavior which already existed from Jan 14 to Jan 30.